### PR TITLE
feat: 엑세스토큰 재발급 테스트코드 추가 (#64)

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -20,3 +20,7 @@ operation::auth/generateRenewalAccessToken[snippets='http-request,request-fields
 [[Auth-엑세스토큰-재발급-에러-잘못된-리프래쉬토큰]]
 === Auth 엑세스토큰 재발급 에러 (잘못된 리프래쉬토큰)
 operation::auth/generateRenewalAccessToken/failByinvalidTokenError[snippets='http-request,request-fields,http-response']
+
+[[Auth-엑세스토큰-재발급-에러-만료된-리프래쉬토큰]]
+=== Auth 엑세스토큰 재발급 에러 (만료된 리프래쉬토큰)
+operation::auth/generateRenewalAccessToken/failByExpireTokenError[snippets='http-request,request-fields,http-response']

--- a/src/main/java/com/rudkids/rudkids/domain/auth/exception/ExpiredTokenException.java
+++ b/src/main/java/com/rudkids/rudkids/domain/auth/exception/ExpiredTokenException.java
@@ -1,8 +1,8 @@
 package com.rudkids.rudkids.domain.auth.exception;
 
-import com.rudkids.rudkids.global.error.exception.BadRequestException;
+import com.rudkids.rudkids.global.error.exception.UnauthorizedException;
 
-public class ExpiredTokenException extends BadRequestException {
+public class ExpiredTokenException extends UnauthorizedException {
     private static final String MESSAGE = "만료된 토큰입니다.";
 
     public ExpiredTokenException() {

--- a/src/test/java/com/rudkids/rudkids/interfaces/auth/AuthControllerTest.java
+++ b/src/test/java/com/rudkids/rudkids/interfaces/auth/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.rudkids.rudkids.interfaces.auth;
 
 import com.rudkids.rudkids.common.ControllerTest;
+import com.rudkids.rudkids.domain.auth.exception.ExpiredTokenException;
 import com.rudkids.rudkids.domain.auth.exception.InvalidTokenException;
 import com.rudkids.rudkids.infrastructure.oauth.exception.OAuthException;
 import org.junit.jupiter.api.DisplayName;
@@ -166,6 +167,30 @@ class AuthControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(USER_엑세스_토큰_재발급_요청())))
                 .andDo(print())
                 .andDo(document("auth/generateRenewalAccessToken/failByinvalidTokenError",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("refreshToken")
+                                        .type(JsonFieldType.STRING)
+                                        .description("잘못된 리프래쉬 토큰")
+                        )
+                ))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @DisplayName("만료된 리프래쉬 토큰으로 요청해서 새로운 엑세스 토큰 요청시 상태코드 401을 반환한다")
+    @Test
+    void 만료된_리프래쉬_토큰으로_요청해서_새로운_엑세스_토큰_요청시_상태코드_401을_반환한다() throws Exception {
+        doThrow(new ExpiredTokenException())
+                .when(authService)
+                .generateRenewalAccessToken(any());
+
+        mockMvc.perform(post("/api/v1/auth/renewal/access")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(USER_엑세스_토큰_재발급_요청())))
+                .andDo(print())
+                .andDo(document("auth/generateRenewalAccessToken/failByExpireTokenError",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(


### PR DESCRIPTION
- [X] 엑세스 토큰 재발급을 위한 리프래쉬 요청을 할 때 만료된 리프래쉬 토큰을 요청하여 실패하는 테스트코드를 작성